### PR TITLE
Fix Absorb Magic

### DIFF
--- a/data/talents/beholder.lua
+++ b/data/talents/beholder.lua
@@ -378,8 +378,9 @@ newTalent{
 	--end,
 	is_spell=true,
 	action = function(self, t)
-		local d d = self:showInventory("Drain which item?", self:getInven("INVEN"), function(o) return o.power_source and o.power_source.arcane and o.material_level and (o.material_level>=self.growth_stage or o.unique or o.rare) and not o.is_tinker end, function(o, item)
+		local d d = self:showInventory("Drain which item?", self:getInven("INVEN"), function(o) return o.power_source and o.power_source.arcane and o.material_level and o.material_level>=self.growth_stage and not o.is_tinker end,
 
+		function(o, item)
 			local amt = 1 	--t.get_growth_points(self, t,o.material_level,unique)
 			if o.material_level==self.growth_stage then
 				amt=0.5

--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ long_name = "Werekracken's Beholder Fork"
 short_name = "wkbeholder"
 for_module = "tome"
 version = { 1, 7, 2 }
-addon_version = {1,7,10}
+addon_version = {1,7,11}
 weight = 100
 author = {"Werekracken"}
 tags = {"Beholder", "Class", "Race", "Monster", "Eyes", "Lasers", "Tentacles"}
@@ -63,6 +63,7 @@ Changelog
 - v1.7.8 Add a ring slot to replace the one lost by the quiver.
 - v1.7.9  Re-fix beholder tile update on growth. When you change faction via your Cloak ability, the faction of your summons change with it. Take out T_ARMOUR_TRAINING = 2 from Beholder race definition, that should be class based.
 - v1.7.10 Normalize talent levels (.0 or .3).
+- v1.7.11 Fix Absorb Magic so you can only drain items whose material level is equal or higher than your growth stage (it wasn't being applied to unique and rare items).
 ]]
 overload = true
 superload = true

--- a/readme.md
+++ b/readme.md
@@ -62,3 +62,4 @@ Mage eyes focus on harnessing the powers of their eyestalks. This caste of behol
 - v1.7.8 Add a ring slot to replace the one lost by the quiver.
 - v1.7.9  Re-fix beholder tile update on growth. When you change faction via your Cloak ability, the faction of your summons change with it. Take out T_ARMOUR_TRAINING = 2 from Beholder race definition, that should be class based.
 - v1.7.10 Normalize talent levels (.0 or .3).
+- v1.7.11 Fix Absorb Magic so you can only drain items whose material level is equal or higher than your growth stage (it wasn't being applied to unique and rare items).


### PR DESCRIPTION
Fix Absorb Magic so you can only drain items whose material level is equal or higher than your growth stage (it wasn't being applied to unique and rare items).