### PR TITLE
Fix talent auto assign

### DIFF
--- a/data/talents/beholder.lua
+++ b/data/talents/beholder.lua
@@ -306,6 +306,7 @@ newTalent{
 	mode = "sustained", no_sustain_autoreset = true,
 	no_energy = true,
 	cooldown = 0,
+	no_unlearn_last = true,
 	is_spell=true,
 	activate = function(self, who)
 		self.old_faction_cloak = self.faction
@@ -373,6 +374,7 @@ newTalent{
 	type = {"race/beholder-other", 1},
 	cooldown = 10,
 	no_npc_use = true,
+	no_unlearn_last = true,
 	--get_growth_points = function(self, t, mlevel,unique)
 	--	return math.max((.5 * (mlevel - self.growth_stage)+ 1) * unique,.5)
 	--end,

--- a/data/talents/spells.lua
+++ b/data/talents/spells.lua
@@ -225,15 +225,15 @@ mage_stage_5 = function(self)
 	game.level.map:particleEmitter(self.x, self.y, 1, "demon_teleport")
 end
 
-newTalentType{  allow_random=true, type="spell/fire-eye", name = "fire-eye", description = "Flame eye abilities" }
-newTalentType{  allow_random=true, type="spell/frost-eye", name = "frost-eye", description = "Frost eye abilities" }
-newTalentType{  allow_random=true, type="spell/lightning-eye", name = "lightning-eye", description = "Lightning eye abilities" }
-newTalentType{  allow_random=true, type="spell/death-eye", name = "death-eye", description = "Death eye abilities\n\n#GOLD##BOLD#You must reach the 5th beholder growth stage to be able to learn this talent tree", beholder_growth_req = 5}
-newTalentType{  allow_random=true, type="spell/tri-beam", name = "tri-beam", description = "Refocus your central eye's energies\n\n#GOLD##BOLD#You must reach the 3rd beholder growth stage to be able to learn this talent tree.", beholder_growth_req = 3 }
-newTalentType{  allow_random=true, type="spell/central-eye", name = "central-eye", description = "Central eye anti-magic abilities" }
-newTalentType{ type="race/beholder-other", name = "beholder-other", generic = true, description = "Special beholder talents." }
-newTalentType{ type="race/beholder", name = "beholder", generic = true, description = "Basic abilities common to all Beholders." }
-newTalentType{ type="technique/tentacle-combat", name = "tentacle-combat", generic = true, description = "Strike nearby foes with your tentacles." }
+newTalentType{ allow_random=false, type="spell/fire-eye", name = "fire-eye", description = "Flame eye abilities" }
+newTalentType{ allow_random=false, type="spell/frost-eye", name = "frost-eye", description = "Frost eye abilities" }
+newTalentType{ allow_random=false, type="spell/lightning-eye", name = "lightning-eye", description = "Lightning eye abilities" }
+newTalentType{ allow_random=false, type="spell/death-eye", name = "death-eye", description = "Death eye abilities\n\n#GOLD##BOLD#You must reach the 5th beholder growth stage to be able to learn this talent tree", beholder_growth_req = 5}
+newTalentType{ allow_random=false, type="spell/tri-beam", name = "tri-beam", description = "Refocus your central eye's energies\n\n#GOLD##BOLD#You must reach the 3rd beholder growth stage to be able to learn this talent tree.", beholder_growth_req = 3 }
+newTalentType{ allow_random=false, type="spell/central-eye", name = "central-eye", description = "Central eye anti-magic abilities" }
+newTalentType{ allow_random=false, type="race/beholder-other", name = "beholder-other", generic = true, description = "Special beholder talents." }
+newTalentType{ allow_random=false, type="race/beholder", name = "beholder", generic = true, description = "Basic abilities common to all Beholders." }
+newTalentType{ allow_random=false, type="technique/tentacle-combat", name = "tentacle-combat", generic = true, description = "Strike nearby foes with your tentacles." }
 -- newTalentType{ type="technique/ravenous-maw", name = "ravenous-maw", description = "Assail foes with your enormous maw and devour them whole, arcane energies and all." }
 
 spells_req1 = {

--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ long_name = "Werekracken's Beholder Fork"
 short_name = "wkbeholder"
 for_module = "tome"
 version = { 1, 7, 2 }
-addon_version = {1,7,14}
+addon_version = {1,7,15}
 weight = 100
 author = {"Werekracken"}
 tags = {"Beholder", "Class", "Race", "Monster", "Eyes", "Lasers", "Tentacles"}
@@ -74,6 +74,7 @@ Changelog
 - v1.7.12 Fix the Draining Gaze map effect so you can see the area of effect of your gaze.
 - v1.7.13 Take the innate Use Tentacles off of non-Mage Eye Beholders and give them Tentacle Combat generic tree unlocked at 1.0 mastery (to help make up for not being able to wear most gear), and make Channel Mastery useful for classes other than Mage Eye. Fix error when trying to unlearn Tentacle Mastery. Add some base game spell talent trees to Mage Eye to keep up with the times (more options). Fix log lines for Manadrain Gaze effect damage. Add class icons from Rexocorum for Mage Eye.
 - v1.7.14 Fix for compatibility with Zizzo's Passive Cooldowns.
+- v1.7.15 Make Absorb Magic and Beholder's Cloak of Deception not unlearnable so that if auto-assign at birth is disabled new chars will still get them.
 ]]
 overload = true
 superload = true

--- a/readme.md
+++ b/readme.md
@@ -73,3 +73,4 @@ Mage eyes focus on harnessing the powers of their eyestalks.
 - v1.7.12 Fix the Draining Gaze map effect so you can see the area of effect of your gaze.
 - v1.7.13 Take the innate Use Tentacles off of non-Mage Eye Beholders and give them Tentacle Combat generic tree unlocked at 1.0 mastery (to help make up for not being able to wear most gear), and make Channel Mastery useful for classes other than Mage Eye. Fix error when trying to unlearn Tentacle Mastery. Add some base game spell talent trees to Mage Eye to expand the options. Fix log lines for Manadrain Gaze effect damage. Add class icons from Rexocorum for Mage Eye.
 - v1.7.14 Fix for compatibility with Zizzo's Passive Cooldowns.
+- v1.7.15 Make Absorb Magic and Beholder's Cloak of Deception not unlearnable so that if auto-assign at birth is disabled new chars will still get them.


### PR DESCRIPTION
Make beholder birth talents unlearnable so that if auto-assign at birth is disabled new chars will still get them. 

Also make all beholder talent trees allow_random=false.
